### PR TITLE
docs: add SPEC.md for cross-language port alignment

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -257,7 +257,7 @@ For `random`, the output is non-deterministic, so test the following properties:
 
 ## 6. Experimental API
 
-> **Status: Unstable.** These functions are not part of the stable public API. Ports may choose to implement or skip them. Signatures and behavior may change without notice.
+> **Status: Unstable.** These functions are not part of the stable public API and are **not exported from the main module entry point** (only `generate`, `validate`, and `random` are public exports). Ports may choose to implement or skip them. Signatures and behavior may change without notice.
 
 ### `generateModN(value, n, options?) -> string`
 


### PR DESCRIPTION
## Summary
- Add `docs/SPEC.md` as the canonical specification for all language ports of the Luhn algorithm library
- Covers public API signatures, algorithm pseudocode, input validation rules (with ordering), test vectors, experimental API, and constraints
- All test vectors and error messages verified against existing `src/luhn.spec.ts` and `src/luhn.ts`

Closes #10

## Test plan
- [x] Verify all test vectors match existing test expectations in `src/luhn.spec.ts`
- [x] Verify all error messages match `handleErrors()` in `src/luhn.ts`
- [x] Verify algorithm walkthrough produces correct check digit for `"7992739871"` → `3`
- [x] Verify validation check order matches source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)