### PR TITLE
refactor: rename luhnModN to checksumModN, add validateModN, deduplicate internals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ yarn lint         # Lint with ESLint
 
 ## Architecture
 
-- `index.ts` - Entry point re-exporting the public API: `generate`, `validate`, `random`, `generateModN`, `luhnModN`
+- `index.ts` - Entry point re-exporting the public API: `generate`, `validate`, `random`, `generateModN`, `validateModN`, `checksumModN`
 - `src/luhn.ts` - All algorithm implementations
 - `src/luhn.spec.ts` - Co-located Jest tests (ts-jest preset)
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -85,19 +85,44 @@ Luhn mod-N variant that computes a check character from an expanded alphabet.
 |---|---|
 | `n` <= 0 or `n` > 36 | `n must be between 1 and 36` |
 
-### `luhnModN(value, n) -> number`
+### `validateModN(value, n) -> boolean`
+
+Determine whether `value` has a valid Luhn mod-N check character as its last character.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `value` | `string` | yes | String where the last character is the check character |
+| `n` | `number` | yes | Modulus (1 to 36 inclusive) |
+
+**Returns:** `true` if the check character is valid, `false` otherwise.
+
+**Errors:**
+
+| Condition | Error message |
+|---|---|
+| Value is not a string | `value must be a string - received <value>` |
+| String is empty | `string cannot be empty` |
+| Length is 1 | `string must be longer than 1 character` |
+| `n` < 1 or `n` > 36 | `n must be between 1 and 36` |
+
+**Behavior:** Strips the last character (the check character), runs `generateModN` on the remainder, and compares the result to the original `value`.
+
+### `checksumModN(value, n) -> number`
 
 Lower-level mod-N check digit calculation. Accepts alphanumeric input (`0-9`, `A-Z`, `a-z`), returns the check digit as an integer.
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `value` | `string` | yes | Alphanumeric string |
-| `n` | `number` | yes | Modulus for the check digit calculation |
+| `n` | `number` | yes | Modulus (1 to 36 inclusive) |
 
 **Errors:**
 
 | Condition | Error message |
 |---|---|
+| Value is not a string | `value must be a string - received <value>` |
+| String is empty | `string cannot be empty` |
+| `n` < 1 or `n` > 36 | `n must be between 1 and 36` |
 | Character not in `0-9`, `A-Z`, `a-z` | `Invalid character: <char>` |
 
 ## 3. Algorithm
@@ -298,4 +323,4 @@ For `random`, the output is non-deterministic, so test the following properties:
 | Check digit range | `0-9` | Single decimal digit |
 | Leading zeros | Preserved | `"0"` -> `"00"`, `"00123"` -> `"001230"` |
 | `random` first digit | `1-9` | Never zero |
-| `CODE_POINTS` alphabet | `0-9A-Z` (36 chars) | Used by experimental mod-N API only |
+| `CODE_POINTS` alphabet | `0-9A-Z` (36 chars) | Used by public mod-N functions |

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-export { generate, validate, random, generateModN, luhnModN } from './src/luhn';
+export { generate, validate, random, generateModN, validateModN, checksumModN } from './src/luhn';

--- a/src/luhn.ts
+++ b/src/luhn.ts
@@ -142,24 +142,6 @@ export function random(length: string): string {
 }
 
 /**
- * Compute a Luhn mod-N checksum for a numeric string using CODE_POINTS mapping
- */
-function generateModNChecksum(value: string, n: number): number {
-  const chars = Array.from(value);
-  let factor = 2;
-  let sum = 0;
-
-  for (let i = chars.length - 1; i >= 0; i--) {
-    let addend = CODE_POINTS.indexOf(chars[i].toUpperCase()) * factor;
-    addend = Math.floor(addend / n) + (addend % n);
-    sum += addend;
-    factor = factor === 2 ? 1 : 2;
-  }
-
-  return (n - (sum % n)) % n;
-}
-
-/**
  * Calculate and append a Luhn mod-N checksum to a numeric string
  *
  * @param value - Numeric string to generate checksum for
@@ -174,10 +156,39 @@ export function generateModN(value: string, n: number, options?: GenerateOptions
     throw new Error('n must be between 1 and 36');
   }
 
-  const checkSum = generateModNChecksum(value, n);
+  const checkSum = checksumModN(value, n);
   const checkChar = CODE_POINTS[checkSum];
 
   return options?.checkSumOnly ? checkChar : value.concat(checkChar);
+}
+
+/**
+ * Determine if the Luhn mod-N checksum for a given value is correct
+ *
+ * @param value - Numeric string where the last character is the check character
+ * @param n - Modulus (base) between 1 and 36
+ * @returns boolean indicating whether the checksum is valid
+ */
+export function validateModN(value: string, n: number): boolean {
+  if (typeof value !== 'string') {
+    throw new Error(`value must be a string - received ${value}`);
+  }
+
+  if (!value.length) {
+    throw new Error('string cannot be empty');
+  }
+
+  if (value.length === 1) {
+    throw new Error('string must be longer than 1 character');
+  }
+
+  if (n < 1 || n > 36) {
+    throw new Error('n must be between 1 and 36');
+  }
+
+  const valueWithoutCheckSum = value.substring(0, value.length - 1);
+
+  return value === generateModN(valueWithoutCheckSum, n);
 }
 
 /**
@@ -200,7 +211,19 @@ function charToInt(char: string): number {
  * @param n - Modulus (base) to use for the algorithm
  * @returns Check digit as a number
  */
-export function luhnModN(value: string, n: number): number {
+export function checksumModN(value: string, n: number): number {
+  if (typeof value !== 'string') {
+    throw new Error(`value must be a string - received ${value}`);
+  }
+
+  if (!value.length) {
+    throw new Error('string cannot be empty');
+  }
+
+  if (n < 1 || n > 36) {
+    throw new Error('n must be between 1 and 36');
+  }
+
   const chars = Array.from(value);
   let factor = 2;
   let sum = 0;


### PR DESCRIPTION
## Summary
- Rename `luhnModN` to `checksumModN` for action-based naming consistency
- Add input validation (type check, empty check, n range) to `checksumModN`
- Add `validateModN` function following the same pattern as `validate`
- Eliminate redundant private `generateModNChecksum` by having `generateModN` call `checksumModN` internally
- Update SPEC.md and CLAUDE.md with new API surface

Closes #30

## Test plan
- [x] All 106 existing + new tests pass (`yarn test`)
- [x] Lint clean (`yarn lint`)
- [x] Build succeeds (`yarn build`)
- [x] Verify `checksumModN` rejects null, undefined, empty string, and out-of-range n
- [x] Verify `validateModN` correctly validates values produced by `generateModN` (including n=16 with alphanumeric check chars)
- [x] Verify `validateModN` returns false for tampered values
- [x] Verify n=10 behavior matches `validate` for numeric inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)