### PR TITLE
feat: add prepublish validation script

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -290,19 +290,15 @@ Potential enhancements to the release process:
    - Add `npm version` script to handle package.json updates
    - Consider semantic-release for fully automated releases
 
-2. **Prepublish validation**
-   - Add `prepublishOnly` script to run tests before publish
-   - Prevent publishing broken builds
-
-3. **Multi-registry support**
+2. **Multi-registry support**
    - Document GitHub Packages installation for consumers
    - Consider publishing to additional registries
 
-4. **Release notes automation**
+3. **Release notes automation**
    - Auto-generate from conventional commits
    - Include contributor attribution
 
-5. **Version 1.0.0 readiness**
+4. **Version 1.0.0 readiness**
    - Finalize API stability
    - Complete documentation
    - Full test coverage including experimental features

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "tsc && node dist/index.js",
     "lint": "eslint .",
     "test": "jest",
-    "changelog": "conventional-changelog -p conventionalcommits -i CHANGELOG.md -s"
+    "changelog": "conventional-changelog -p conventionalcommits -i CHANGELOG.md -s",
+    "prepublishOnly": "yarn lint && yarn test && yarn build"
   },
   "devDependencies": {
     "@types/jest": "^29.2.3",


### PR DESCRIPTION
## Summary
- Add `prepublishOnly` script to package.json that runs `yarn lint && yarn test && yarn build` before any npm publish
- Remove completed "Prepublish validation" item from docs/RELEASE.md future improvements

Closes #23

## Test plan
- [x] `yarn test` — 106 tests pass
- [x] `yarn lint` — clean
- [x] `yarn build` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)