### PR TITLE
chore: fix copyright automation and include LICENSE

### DIFF
--- a/.github/workflows/update-copyright-date.yml
+++ b/.github/workflows/update-copyright-date.yml
@@ -1,37 +1,27 @@
-name: update copyright date in README
+name: update copyright date
 
 on:
-  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
   schedule:
-    # The shortest interval you can run scheduled workflows is once every 5 minutes.
-    # Note: The schedule event can be delayed during periods of high loads of GitHub Actions workflow runs.
-    # High load times include the start of every hour.
-    # To decrease the chance of delay, schedule your workflow to run at a different time of the hour.
-    # Every 5 minutes.
-    # - cron: '*/5 * * * *'
-    # At the beginning of every day.
-    # - cron: "0 0 * * *"
     # At the beginning of every year.
     - cron: "0 0 1 1 *"
 
-# on: [push]
-
 jobs:
-  report:
+  update-copyright:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out repository code
-        # https://github.com/actions/checkout/tree/v3.0.2
-        uses: actions/checkout@v3
-      - name: Modify date and time
-        run: |
-          ./update-copyright-date.sh README.md
-          cat README.md
-      - name: Push to repository
-        run: |
-          git config --global user.name "Ryan Rembert"
-          git config --global user.email "jrrembert@users.noreply.github.com"
-          now=$(date)  
-          git add -A
-          git commit -m "update copryright year"
-          git push
+        uses: actions/checkout@v4
+      - name: Update copyright years
+        run: ./update-copyright-date.sh README.md LICENSE
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update copyright year"
+          branch: chore/update-copyright-${{ github.run_id }}
+          title: "chore: update copyright year"
+          body: "Automated annual copyright year update for README.md and LICENSE."
+          labels: dependencies

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 J. Ryan Rembert
+Copyright (c) 2022-2026 J. Ryan Rembert
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ A TypeScript implementation of the Luhn algorithm for generating and validating 
 
 [MIT](LICENSE)
 
-Copyright © 2022-2025 J. Ryan Rembert
+Copyright © 2022-2026 J. Ryan Rembert

--- a/update-copyright-date.sh
+++ b/update-copyright-date.sh
@@ -1,25 +1,28 @@
 #!/bin/bash
 
-# Check if file is provided as argument
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 <markdown_file>"
+# Check if at least one file is provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <file1> [file2] ..."
     exit 1
 fi
 
-file="$1"
 current_year=$(date +"%Y")
 
-# Check if file exists
-if [ ! -f "$file" ]; then
-    echo "Error: File $file not found"
-    exit 1
-fi
+for file in "$@"; do
+  # Check if file exists
+  if [ ! -f "$file" ]; then
+      echo "Error: File $file not found"
+      exit 1
+  fi
 
-# Update copyright years with company name
-# Matches any year or year range between © and the rest of the line
-sed -i.bak -E "s/(© )([0-9]{4})([-][0-9]{4})?/\1\2-$current_year/" "$file"
+  # Update "© YYYY" or "© YYYY-YYYY" patterns (README.md)
+  sed -i.bak -E "s/(© )([0-9]{4})([-][0-9]{4})?/\1\2-$current_year/" "$file"
 
-# Remove backup file
-rm "${file}.bak"
+  # Update "(c) YYYY" or "(c) YYYY-YYYY" patterns (LICENSE)
+  sed -i.bak -E "s/(\(c\) )([0-9]{4})([-][0-9]{4})?/\1\2-$current_year/" "$file"
 
-echo "Copyright years updated in $file"
+  # Remove backup file
+  rm "${file}.bak"
+
+  echo "Copyright years updated in $file"
+done


### PR DESCRIPTION
## Summary
- Fix workflow to create a PR via `peter-evans/create-pull-request@v7` instead of pushing directly to `main` (which branch protection blocks — caused the Jan 1, 2026 failure)
- Extend `update-copyright-date.sh` to accept multiple files and support `(c)` pattern for LICENSE
- Update copyright years to 2026 in both README.md and LICENSE

Closes #44

## Test plan
- [x] `yarn test` — 106 tests pass
- [x] `yarn lint` — clean
- [x] `yarn build` — compiles
- [x] README.md shows `Copyright © 2022-2026`
- [x] LICENSE shows `Copyright (c) 2022-2026`
- [x] Script works with multiple file arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)