### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report a bug
+labels: bug
+---
+
+## Description
+
+<!-- What happened? -->
+
+## Steps to reproduce
+
+1.
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Environment
+
+- Node.js version:
+- Package version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest a new feature
+labels: enhancement
+---
+
+## Description
+
+<!-- What would you like to see added? -->
+
+## Use case
+
+<!-- Why is this needed? What problem does it solve? -->


### PR DESCRIPTION
## Summary

Add GitHub issue templates for bug reports and feature requests.

Closes #57

## Changes

- Add `.github/ISSUE_TEMPLATE/bug_report.md` with description, repro steps, expected behavior, and environment sections
- Add `.github/ISSUE_TEMPLATE/feature_request.md` with description and use case sections

## Test plan

- [x] Templates are valid markdown with correct frontmatter
- [x] Placed in correct location (`.github/ISSUE_TEMPLATE/`)