### PR TITLE
docs: add contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thanks for your interest in contributing to luhnjs!
+
+## Getting Started
+
+```bash
+git clone https://github.com/jrrembert/luhnjs.git
+cd luhnjs
+yarn install
+```
+
+## Development
+
+```bash
+yarn lint    # Run ESLint
+yarn test    # Run tests
+yarn build   # Compile TypeScript
+```
+
+## Workflow
+
+1. Open a GitHub issue describing the change
+2. Create a branch from `rc` (for `feat:`/`fix:` changes) or `main` (for `docs:`/`chore:` changes)
+   - Branch naming: `feature/`, `fix/`, `chore/`, `docs/` prefixes
+3. Write a failing test, then implement the fix or feature (TDD)
+4. Ensure `yarn lint && yarn test && yarn build` all pass
+5. Commit using [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
+6. Open a pull request with `Closes #N` in the description
+
+## Code Style
+
+ESLint enforces the project's style. Run `yarn lint` to check. Key rules: single quotes, 2-space indentation, semicolons required, trailing commas on multiline.


### PR DESCRIPTION
## Summary

Add CONTRIBUTING.md with guidelines for getting started, development commands, workflow, and code style.

Closes #55

## Changes

- Add `CONTRIBUTING.md` covering setup, development commands, branching workflow (TDD, conventional commits), and code style

## Test plan

- [x] File is valid markdown
- [x] Instructions are consistent with CLAUDE.md