### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it privately by emailing **jrrembert@gmail.com**.
+If you discover a security vulnerability, please report it privately by emailing **j.ryan.rembert@gmail.com**.
 
 Please do **not** open a public GitHub issue for security vulnerabilities.
 
@@ -14,4 +14,4 @@ Please do **not** open a public GitHub issue for security vulnerabilities.
 
 ## Response
 
-You can expect an initial response within 72 hours. Once confirmed, a fix will be prioritized and released as a patch version.
+You can expect an initial response within 72 hours. Once confirmed, a fix will be prioritized and released as a patch.


### PR DESCRIPTION
## Summary

Add SECURITY.md with instructions for privately reporting security vulnerabilities.

Closes #56

## Changes

- Add `SECURITY.md` with reporting instructions, what to include, and response expectations

## Test plan

- [x] File is valid markdown
- [x] Contact email is correct