### PR TITLE
docs: add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+Please read the full text at the link above. In summary, we are committed to providing a welcoming and inclusive environment for everyone.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to **j.ryan.rembert@gmail.com**. All complaints will be reviewed and investigated promptly and fairly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing to luhnjs!
+Thanks for your interest in contributing to luhnjs! Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

Add a Code of Conduct referencing Contributor Covenant v2.1, and link to it from CONTRIBUTING.md.

Closes #54

## Changes

- Add `CODE_OF_CONDUCT.md` linking to Contributor Covenant v2.1 with enforcement contact
- Update `CONTRIBUTING.md` to reference the Code of Conduct

## Test plan

- [x] Files are valid markdown
- [x] Enforcement email matches SECURITY.md contact