### PR TITLE
fix: improve error messages in random() for clarity

### DIFF
--- a/src/luhn.spec.ts
+++ b/src/luhn.spec.ts
@@ -136,8 +136,8 @@ describe('random', () => {
     { length: undefined as any, message: 'value must be a string - received undefined', spec: 'string cannot be null/undefined' },
     { length: '', message: 'string cannot be empty', spec: 'string is empty' },
     { length: '1a', message: 'string must be convertible to a number', spec: 'string cannot be converted to a number' },
-    { length: '1', message: 'string must be greater than 1', spec: 'string has a length of 1' },
-    { length: '1'.repeat(99), message: 'string must be less than 100 characters', spec: 'string is longer than 100 characters' },
+    { length: '1', message: 'length must be greater than or equal to 2', spec: 'length is less than 2' },
+    { length: '101', message: 'length must be less than or equal to 100', spec: 'length is greater than 100' },
   ])('should throw error when $spec', ({ length, message }) => {
     const actual = () => luhn.random(length);
 

--- a/src/luhn.ts
+++ b/src/luhn.ts
@@ -122,11 +122,11 @@ export function random(length: string): string {
   const lengthAsInteger = parseInt(length);
 
   if (lengthAsInteger > 100) {
-    throw new Error('string must be less than 100 characters');
+    throw new Error('length must be less than or equal to 100');
   }
 
   if (lengthAsInteger < 2) {
-    throw new Error('string must be greater than 1');
+    throw new Error('length must be greater than or equal to 2');
   }
 
   const random = Array.from({ length: lengthAsInteger - 1 }, (_, index) => {


### PR DESCRIPTION
## Summary

Improve error messages in `random()` to reference "length" instead of "string", making them clearer for consumers.

Closes #65

## Changes

- Update error message from "string must be less than 100 characters" to "length must be less than or equal to 100"
- Update error message from "string must be greater than 1" to "length must be greater than or equal to 2"
- Update corresponding test expectations

## Test plan

- [x] `yarn lint` passes
- [x] `yarn test` passes (106/106)
- [x] `yarn build` passes