### PR TITLE
chore: add PR title validation workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,27 @@
+name: PR Title Validation
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            test


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-title.yml` using `amannn/action-semantic-pull-request@v5`
- Triggers on `pull_request_target` (opened, edited, synchronize)
- Allows types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`
- Updated `docs/CI.md` to document the new workflow
- Added `Validate PR title` as a required status check on both `main` and `rc` branch protection rules

## Changes

- `.github/workflows/pr-title.yml` — new workflow file
- `docs/CI.md` — added workflow #5 section, updated permissions and protected branches tables, updated CI history

## Test plan

- [ ] Open a PR with an invalid title (e.g. `add something`) → check fails
- [ ] Open a PR with a valid title (e.g. `feat: add something`) → check passes
- [ ] Confirm `Validate PR title` appears as a required check on `main` and `rc`

Closes #62