### PR TITLE
feat: publish to GitHub Packages in addition to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Test
         run: yarn test
 
+      - name: Configure GitHub Packages auth
+        run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@jrrembert:registry=https://npm.pkg.github.com

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,6 +15,12 @@
         "npmPublish": true
       }
     ],
+    [
+      "@semantic-release/exec",
+      {
+        "publishCmd": "npm publish --registry https://npm.pkg.github.com --tag ${nextRelease.channel || 'latest'}"
+      }
+    ],
     "@semantic-release/github"
   ]
 }

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -145,7 +145,7 @@ See [RELEASE.md](RELEASE.md) for detailed documentation.
 - **Node version**: 22.x
 - **Steps**: lint → build → test → `npx semantic-release`
 - **Publishes to**: npm (https://registry.npmjs.org)
-- **Authentication**: `NPM_TOKEN` secret, automatic `GITHUB_TOKEN`
+- **Authentication**: `NPM_TOKEN` secret (npm), automatic `GITHUB_TOKEN` (GitHub Packages)
 - **Skips release** if no `feat:` or `fix:` commits since last release
 
 ### 4. Copyright Update

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -124,15 +124,16 @@ semantic-release is configured in `.releaserc.json` with these plugins:
 
 1. `@semantic-release/commit-analyzer` — determines version bump from commits
 2. `@semantic-release/release-notes-generator` — generates release notes
-3. `@semantic-release/npm` — publishes to npm
-4. `@semantic-release/github` — creates GitHub Release
+3. `@semantic-release/npm` — publishes to npm (registry.npmjs.org)
+4. `@semantic-release/exec` — publishes to GitHub Packages (npm.pkg.github.com)
+5. `@semantic-release/github` — creates GitHub Release
 
 ### Environment Requirements
 
 The release workflow requires these secrets:
 
 - `NPM_TOKEN` — npm publish authentication (configured in repository settings)
-- `GITHUB_TOKEN` — automatic, provided by GitHub Actions
+- `GITHUB_TOKEN` — automatic, provided by GitHub Actions (also used for GitHub Packages auth via `.npmrc`)
 
 ### Verification
 
@@ -145,7 +146,10 @@ npm view @jrrembert/luhnjs versions
 # Check latest version
 npm view @jrrembert/luhnjs version
 
-# Install and test
+# Check GitHub Packages
+gh api /orgs/jrrembert/packages/npm/luhnjs/versions
+
+# Install and test (npm)
 npm install @jrrembert/luhnjs@latest
 ```
 
@@ -244,11 +248,7 @@ This is no longer an issue with semantic-release — version management is fully
 
 Potential enhancements to the release process:
 
-1. **Multi-registry support**
-   - Document GitHub Packages installation for consumers
-   - Consider publishing to additional registries
-
-2. **Version 1.0.0 readiness**
+1. **Version 1.0.0 readiness**
    - Finalize API stability
    - Complete documentation
    - Full test coverage including experimental features

--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
     "prepublishOnly": "yarn lint && yarn test && yarn build"
   },
   "devDependencies": {
+    "@semantic-release/exec": "^7.1.0",
     "@types/jest": "^29.2.3",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
     "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^8.28.0",
     "jest": "^29.3.1",
+    "semantic-release": "^24.0.0",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
-    "semantic-release": "^24.0.0",
     "typescript": "^4.9.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,6 +979,18 @@
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-4.0.0.tgz#692810288239637f74396976a9340fbc0aa9f6f9"
   integrity sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==
 
+"@semantic-release/exec@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@semantic-release/exec/-/exec-7.1.0.tgz#cfaffe85a589aa0f385eede256904ce70acb829f"
+  integrity sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==
+  dependencies:
+    "@semantic-release/error" "^4.0.0"
+    aggregate-error "^3.0.0"
+    debug "^4.0.0"
+    execa "^9.0.0"
+    lodash-es "^4.17.21"
+    parse-json "^8.0.0"
+
 "@semantic-release/github@^11.0.0":
   version "11.0.6"
   resolved "https://registry.yarnpkg.com/@semantic-release/github/-/github-11.0.6.tgz#3320c373334858a3aefb11cf75abccb7cc438040"
@@ -1395,6 +1407,14 @@ agent-base@^7.1.0, agent-base@^7.1.2:
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
   integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
+aggregate-error@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
+  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
+
 aggregate-error@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-5.0.0.tgz#ffe15045d7521c51c9d618e3d7f37c13f29b3fd3"
@@ -1761,6 +1781,11 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
+
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 clean-stack@^5.2.0:
   version "5.3.0"
@@ -2818,6 +2843,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 indent-string@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary

Adds GitHub Packages as a second publish target alongside npm. Every release now publishes to both `registry.npmjs.org` and `npm.pkg.github.com`.

## Changes

- `.npmrc` (new) — maps `@jrrembert` scope to GitHub Packages and configures auth via `${GITHUB_TOKEN}` env var substitution
- `.releaserc.json` — adds a second `@semantic-release/npm` plugin entry targeting `https://npm.pkg.github.com`
- `docs/RELEASE.md` — updates plugin list, environment requirements, verification steps; removes completed Future Improvements item
- `docs/CI.md` — clarifies that `NPM_TOKEN` is for npm and `GITHUB_TOKEN` is for GitHub Packages

## How auth works

Project-level `.npmrc` has higher precedence than user-level `~/.npmrc`. The project `.npmrc` configures `//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}`, which npm substitutes at runtime. `GITHUB_TOKEN` (with `packages: write`) is already available in the release workflow.

## Test plan

- [ ] Merge to `rc` and verify the release workflow publishes to both registries
- [ ] Confirm package appears in GitHub Packages after release

Closes #74