### PR TITLE
refactor: replace GenerateOptions class with interface

### DIFF
--- a/src/luhn.ts
+++ b/src/luhn.ts
@@ -1,11 +1,7 @@
 const CODE_POINTS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
-class GenerateOptions {
-  public checkSumOnly: boolean;
-
-  constructor() {
-    this.checkSumOnly = false;
-  }
+interface GenerateOptions {
+  checkSumOnly: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

`GenerateOptions` was defined as a class but never instantiated — it was only used as a type annotation. The constructor setting `checkSumOnly = false` was dead code.

## Changes

- `src/luhn.ts` — replaced `class GenerateOptions` with `interface GenerateOptions` (6 lines → 2 lines)

## Test plan

- [x] All 106 tests pass

Closes #88