### PR TITLE
chore: upgrade TypeScript 4 to 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "semantic-release": "^24.0.0",
-    "typescript": "^4.9.3"
+    "typescript": "^5.8.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,15 @@
 {
     "compilerOptions": {
         "target": "es2017",
+        "lib": ["es2017", "esnext.disposable"],
         "module": "commonjs",
         "declaration": true,
         "esModuleInterop": true,
         "strict": true,
         "moduleResolution": "node",
         "importHelpers": true,
-        "outDir": "dist"
+        "outDir": "dist",
+        "skipLibCheck": true
     },
     "include": [
       "index.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5369,10 +5369,10 @@ type-fest@^4.39.1, type-fest@^4.41.0, type-fest@^4.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
   integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
-typescript@^4.9.3:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+typescript@^5.8.2:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 uglify-js@^3.1.4:
   version "3.19.3"


### PR DESCRIPTION
## Summary
- Bumps `typescript` from `^4.9.3` to `^5.8.2`
- Adds `lib: ["es2017", "esnext.disposable"]` to `tsconfig.json` (required by jest 30 types)
- Adds `skipLibCheck: true` to avoid `@types/node` conflicts with TS 5

## Changes
- `package.json`: typescript `^4.9.3` → `^5.8.2`
- `tsconfig.json`: add `lib` and `skipLibCheck` compilerOptions
- `yarn.lock`: updated

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (106 tests)

Closes #103