### PR TITLE
chore: fix invalid lib option in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "es2017",
-        "lib": ["es2017", "esnext.disposable"],
+        "lib": ["es2017"],
         "module": "commonjs",
         "declaration": true,
         "esModuleInterop": true,


### PR DESCRIPTION
## Summary
Remove invalid `esnext.disposable` TypeScript lib option that prevents Jest from running. Mirror of the same fix already on `main` (#114).

## Changes
- Remove `esnext.disposable` from `tsconfig.json` `lib` array

## Test plan
- [x] `yarn test` passes after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)